### PR TITLE
Ncag regex support

### DIFF
--- a/devU-api/package-lock.json
+++ b/devU-api/package-lock.json
@@ -25,6 +25,7 @@
         "passport-saml": "^3.2.2",
         "pg": "^8.4.0",
         "reflect-metadata": "^0.1.10",
+        "regex-parser": "^2.3.0",
         "swagger-jsdoc": "^6.1.0",
         "swagger-ui-express": "^4.1.6",
         "typeorm": "0.2.32"
@@ -10114,6 +10115,11 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
       "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+    },
+    "node_modules/regex-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-parser/-/regex-parser-2.3.0.tgz",
+      "integrity": "sha512-TVILVSz2jY5D47F4mA4MppkBrafEaiUWJO/TcZHEIuI13AqoZMkK1WMA4Om1YkYbTx+9Ki1/tSUXbceyr9saRg=="
     },
     "node_modules/require-directory": {
       "version": "2.1.1",

--- a/devU-api/package.json
+++ b/devU-api/package.json
@@ -72,6 +72,7 @@
     "passport-saml": "^3.2.2",
     "pg": "^8.4.0",
     "reflect-metadata": "^0.1.10",
+    "regex-parser": "^2.3.0",
     "swagger-jsdoc": "^6.1.0",
     "swagger-ui-express": "^4.1.6",
     "typeorm": "0.2.32"

--- a/devU-api/scripts/populate-db.ts
+++ b/devU-api/scripts/populate-db.ts
@@ -1,9 +1,7 @@
 const API_URL = 'http://localhost:3001'
 
 //Set to a valid refreshToken, which is set as a cookie after logging in at localhost:9000
-const TOKEN =
-  'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InNrMDcxMTIwMjEifQ.eyJ1c2VySWQiOjEsImlzUmVmcmVzaFRva2VuIjp0cnVlLCJpYXQiOjE3MDg2NTk1NDYsImV4cCI6MTcwOTUyMzU0NiwiYXVkIjpbImRldlUtYXBpIiwiZGV2VS1jbGllbnQiXSwiaXNzIjoiZGV2VS1hdXRoIiwic3ViIjoiMSJ9.anY1qvejfvqhz73I8Wel7n8LjEh6mJsqnAESJ3miir4jdVuSCA5bwsEjln02l9q1JpwixR3P3J_kbob6yKHGNNk7Nxd3Vw-fYHBQTbpatAKESu2APWJo196GqN1_Rij4uAYzkUt4_TJ_kl1OBEAxx-VjX7-JLk9JWqIsg829NiarRO8qFG-Uyv7br-UaJnmOtFNgaETmYV8TMSY344m7ETPvjJ9VtXkCVl45SBNOp7o3_NGTOAhK6Jlw4cj3L2vsG8x2DH4KEFBsy73hfJv8ONy9y6ypKGEK12votV_G0fhSbGo6-DG9k4Fx1Xucus1By_hQPPg3G43fGWVAWuDv0bEbm68LZBQgio5Bi2L5ndxUa-D5LAFy2PTMFWQeuhsC_pEEhqemQCtU4uBdriE3xiFy0KQmfzQxBOYq8iRPaKoQHmn2hDn3kUyh9Sze92MwdV_T-PAovha4wQee5dtvjmzZUZQVisUjk2CR67EInzSWrcC11BMXWVXvatZjRQ_o\n'
-
+const TOKEN = ''
 //Returns the ID of the newly created entry
 async function SendPOST(path: string, requestBody: string) {
   let response = await fetch(API_URL + path, {

--- a/devU-api/scripts/populate-db.ts
+++ b/devU-api/scripts/populate-db.ts
@@ -1,32 +1,33 @@
-const API_URL = "http://localhost:3001"
+const API_URL = 'http://localhost:3001'
 
 //Set to a valid refreshToken, which is set as a cookie after logging in at localhost:9000
-const TOKEN = ""
+const TOKEN =
+  'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InNrMDcxMTIwMjEifQ.eyJ1c2VySWQiOjEsImlzUmVmcmVzaFRva2VuIjp0cnVlLCJpYXQiOjE3MDg2NTk1NDYsImV4cCI6MTcwOTUyMzU0NiwiYXVkIjpbImRldlUtYXBpIiwiZGV2VS1jbGllbnQiXSwiaXNzIjoiZGV2VS1hdXRoIiwic3ViIjoiMSJ9.anY1qvejfvqhz73I8Wel7n8LjEh6mJsqnAESJ3miir4jdVuSCA5bwsEjln02l9q1JpwixR3P3J_kbob6yKHGNNk7Nxd3Vw-fYHBQTbpatAKESu2APWJo196GqN1_Rij4uAYzkUt4_TJ_kl1OBEAxx-VjX7-JLk9JWqIsg829NiarRO8qFG-Uyv7br-UaJnmOtFNgaETmYV8TMSY344m7ETPvjJ9VtXkCVl45SBNOp7o3_NGTOAhK6Jlw4cj3L2vsG8x2DH4KEFBsy73hfJv8ONy9y6ypKGEK12votV_G0fhSbGo6-DG9k4Fx1Xucus1By_hQPPg3G43fGWVAWuDv0bEbm68LZBQgio5Bi2L5ndxUa-D5LAFy2PTMFWQeuhsC_pEEhqemQCtU4uBdriE3xiFy0KQmfzQxBOYq8iRPaKoQHmn2hDn3kUyh9Sze92MwdV_T-PAovha4wQee5dtvjmzZUZQVisUjk2CR67EInzSWrcC11BMXWVXvatZjRQ_o\n'
 
 //Returns the ID of the newly created entry
 async function SendPOST(path: string, requestBody: string) {
-    let response = await fetch(API_URL + path, {
-        method: "POST",
-        headers: {
-            "Authorization": "Bearer " + TOKEN,
-            "Content-Type": "application/json"
-        },
-        body: requestBody
-    })
-    if (response.status == 401 || response.status == 403) {
-        console.log("Status code: " + response.status)
-        const responseBody = await response.json()
-        console.log(responseBody)
-        throw new Error("401 or 403 HTTP Response Received, make sure you set the TOKEN constant to a valid auth token")
-    } else if (response.status >= 400) {
-        console.log("Status code: " + response.status)
-        const responseBody = await response.json()
-        console.log(responseBody)
-        throw new Error("400/500 Level HTTP Response Received: " + response.status)
-    } else {
-        const responseBody = await response.json()
-        return responseBody.id
-    }
+  let response = await fetch(API_URL + path, {
+    method: 'POST',
+    headers: {
+      'Authorization': 'Bearer ' + TOKEN,
+      'Content-Type': 'application/json',
+    },
+    body: requestBody,
+  })
+  if (response.status == 401 || response.status == 403) {
+    console.log('Status code: ' + response.status)
+    const responseBody = await response.json()
+    console.log(responseBody)
+    throw new Error('401 or 403 HTTP Response Received, make sure you set the TOKEN constant to a valid auth token')
+  } else if (response.status >= 400) {
+    console.log('Status code: ' + response.status)
+    const responseBody = await response.json()
+    console.log(responseBody)
+    throw new Error('400/500 Level HTTP Response Received: ' + response.status)
+  } else {
+    const responseBody = await response.json()
+    return responseBody.id
+  }
 }
 
 /*
@@ -43,148 +44,278 @@ async function SendPOST(path: string, requestBody: string) {
     hasn't submitted anything
 */
 async function RunRequests() {
-    try {
-        //Users
-        const userBilly = await SendPOST("/users", JSON.stringify({
-            email: "billy@buffalo.edu", externalId: "billy", preferredName: "Billiam"
-        }))
-        const userBob = await SendPOST("/users", JSON.stringify({
-            email: "bob@buffalo.edu", externalId: "bob", preferredName: "Bobby"
-        }))
-        const userJones = await SendPOST("/users", JSON.stringify({
-            email: "jones@buffalo.edu", externalId: "jones", preferredName: "Jones"
-        }))
+  try {
+    //Users
+    const userBilly = await SendPOST('/users', JSON.stringify({
+      email: 'billy@buffalo.edu', externalId: 'billy', preferredName: 'Billiam',
+    }))
+    const userBob = await SendPOST('/users', JSON.stringify({
+      email: 'bob@buffalo.edu', externalId: 'bob', preferredName: 'Bobby',
+    }))
+    const userJones = await SendPOST('/users', JSON.stringify({
+      email: 'jones@buffalo.edu', externalId: 'jones', preferredName: 'Jones',
+    }))
 
 
-        //Courses
-        const course312 = await SendPOST("/courses", JSON.stringify({
-            name: "Web Applications", semester: "s2024", number: "CSE312", startDate: "2024-01-24T00:00:00-0500", endDate: "2024-05-10T23:59:59-0500"
-        }))
-        const course302 = await SendPOST("/courses", JSON.stringify({
-            name: "Intro to Experiential Learning", semester: "s2024", number: "CSE302", startDate: "2024-01-24T00:00:00-0500", endDate: "2024-05-07T23:59:59-0500"
-        }))
+    //Courses
+    const course312 = await SendPOST('/courses', JSON.stringify({
+      name: 'Web Applications',
+      semester: 's2024',
+      number: 'CSE312',
+      startDate: '2024-01-24T00:00:00-0500',
+      endDate: '2024-05-10T23:59:59-0500',
+    }))
+    const course302 = await SendPOST('/courses', JSON.stringify({
+      name: 'Intro to Experiential Learning',
+      semester: 's2024',
+      number: 'CSE302',
+      startDate: '2024-01-24T00:00:00-0500',
+      endDate: '2024-05-07T23:59:59-0500',
+    }))
 
 
-        //UserCourse
-        SendPOST("/user-courses", JSON.stringify({
-            userId: userBilly, courseId: course302, level: "student", dropped: false
-        }))
-        SendPOST("/user-courses", JSON.stringify({
-            userId: userBob, courseId: course312, level: "student", dropped: false
-        }))
-        SendPOST("/user-courses", JSON.stringify({
-            userId: userJones, courseId: course302, level: "student", dropped: false
-        }))
-        SendPOST("/user-courses", JSON.stringify({
-            userId: userJones, courseId: course312, level: "student", dropped: false
-        }))
-        
-
-        //Assignments
-        const assign312_1 = await SendPOST("/assignments", JSON.stringify({
-            courseId: course312, name: "Homework 1", startDate: "2024-02-05T00:00:00-0500", dueDate: "2024-02-26T23:59:59-0500", endDate: "2024-03-11T23:59:59-0500", 
-            gradingType: "code", categoryName: "Homework", description: "HTTP", maxFileSize: 10000000, maxSubmissions: 10, disableHandins: false
-        }))
-        const assign312_2 = await SendPOST("/assignments", JSON.stringify({
-            courseId: course312, name: "Homework 2", startDate: "2024-02-19T00:00:00-0500", dueDate: "2024-03-11T23:59:59-0500", endDate: "2024-04-01T23:59:59-0500", 
-            gradingType: "code", categoryName: "Homework", description: "Authentication", maxFileSize: 10000000, maxSubmissions: 10, disableHandins: false
-        }))
-        SendPOST("/assignments", JSON.stringify({
-            courseId: course312, name: "Homework 3", startDate: "2024-03-04T00:00:00-0500", dueDate: "2024-04-01T23:59:59-0500", endDate: "2024-04-15T23:59:59-0500", 
-            gradingType: "code", categoryName: "Homework", description: "Image Uploads", maxFileSize: 10000000, maxSubmissions: 10, disableHandins: false
-        }))
-        const assign312_quiz = await SendPOST("/assignments", JSON.stringify({
-            courseId: course312, name: "2/19 Quiz", startDate: "2024-02-09T16:00:00-0500", dueDate: "2024-02-09T17:00:00-0500", endDate: "2024-02-09T17:00:00-0500", 
-            gradingType: "non-code", categoryName: "Quizzes", description: "Pop quiz!", maxFileSize: 10000000, maxSubmissions: 1, disableHandins: false
-        }))
-        const assign302_1 = await SendPOST("/assignments", JSON.stringify({
-            courseId: course302, name: "Sprint 1", startDate: "2024-01-26T00:00:00-0500", dueDate: "2024-02-17T23:59:59-0500", endDate: "2024-02-17T23:59:59-0500", 
-            gradingType: "manual", categoryName: "Sprints", description: "The First Sprint", maxFileSize: 10000000, disableHandins: false
-        }))
-        const assign302_2 = await SendPOST("/assignments", JSON.stringify({
-            courseId: course302, name: "Sprint 2", startDate: "2024-02-17T00:00:00-0500", dueDate: "2024-03-09T23:59:59-0500", endDate: "2024-03-09T23:59:59-0500", 
-            gradingType: "manual", categoryName: "Sprints", description: "The Second Sprint", maxFileSize: 10000000, disableHandins: false
-        }))
-        SendPOST("/assignments", JSON.stringify({
-            courseId: course302, name: "Sprint 3", startDate: "2024-04-06T00:00:00-0500", dueDate: "2024-04-06T23:59:59-0500", endDate: "2024-04-06T23:59:59-0500", 
-            gradingType: "manual", categoryName: "Sprints", description: "The Third Sprint", maxFileSize: 10000000, disableHandins: false
-        }))
+    //UserCourse
+    SendPOST('/user-courses', JSON.stringify({
+      userId: userBilly, courseId: course302, level: 'student', dropped: false,
+    }))
+    SendPOST('/user-courses', JSON.stringify({
+      userId: userBob, courseId: course312, level: 'student', dropped: false,
+    }))
+    SendPOST('/user-courses', JSON.stringify({
+      userId: userJones, courseId: course302, level: 'student', dropped: false,
+    }))
+    SendPOST('/user-courses', JSON.stringify({
+      userId: userJones, courseId: course312, level: 'student', dropped: false,
+    }))
 
 
-        //AssignmentProblems
-        const assign312_quiz_q1 = await SendPOST("/assignment-problems", JSON.stringify({
-            assignmentId: assign312_quiz, problemName: "q1", maxScore: 5
-        }))
-        const assign312_quiz_q2 = await SendPOST("/assignment-problems", JSON.stringify({
-            assignmentId: assign312_quiz, problemName: "q2", maxScore: 5
-        }))
+    //Assignments
+    const assign312_1 = await SendPOST('/assignments', JSON.stringify({
+      courseId: course312,
+      name: 'Homework 1',
+      startDate: '2024-02-05T00:00:00-0500',
+      dueDate: '2024-02-26T23:59:59-0500',
+      endDate: '2024-03-11T23:59:59-0500',
+      gradingType: 'code',
+      categoryName: 'Homework',
+      description: 'HTTP',
+      maxFileSize: 10000000,
+      maxSubmissions: 10,
+      disableHandins: false,
+    }))
+    const assign312_2 = await SendPOST('/assignments', JSON.stringify({
+      courseId: course312,
+      name: 'Homework 2',
+      startDate: '2024-02-19T00:00:00-0500',
+      dueDate: '2024-03-11T23:59:59-0500',
+      endDate: '2024-04-01T23:59:59-0500',
+      gradingType: 'code',
+      categoryName: 'Homework',
+      description: 'Authentication',
+      maxFileSize: 10000000,
+      maxSubmissions: 10,
+      disableHandins: false,
+    }))
+    SendPOST('/assignments', JSON.stringify({
+      courseId: course312,
+      name: 'Homework 3',
+      startDate: '2024-03-04T00:00:00-0500',
+      dueDate: '2024-04-01T23:59:59-0500',
+      endDate: '2024-04-15T23:59:59-0500',
+      gradingType: 'code',
+      categoryName: 'Homework',
+      description: 'Image Uploads',
+      maxFileSize: 10000000,
+      maxSubmissions: 10,
+      disableHandins: false,
+    }))
+    const assign312_quiz = await SendPOST('/assignments', JSON.stringify({
+      courseId: course312,
+      name: '2/19 Quiz',
+      startDate: '2024-02-09T16:00:00-0500',
+      dueDate: '2024-02-09T17:00:00-0500',
+      endDate: '2024-02-09T17:00:00-0500',
+      gradingType: 'non-code',
+      categoryName: 'Quizzes',
+      description: 'Pop quiz!',
+      maxFileSize: 10000000,
+      maxSubmissions: 1,
+      disableHandins: false,
+    }))
+    const assign302_1 = await SendPOST('/assignments', JSON.stringify({
+      courseId: course302,
+      name: 'Sprint 1',
+      startDate: '2024-01-26T00:00:00-0500',
+      dueDate: '2024-02-17T23:59:59-0500',
+      endDate: '2024-02-17T23:59:59-0500',
+      gradingType: 'manual',
+      categoryName: 'Sprints',
+      description: 'The First Sprint',
+      maxFileSize: 10000000,
+      disableHandins: false,
+    }))
+    const assign302_2 = await SendPOST('/assignments', JSON.stringify({
+      courseId: course302,
+      name: 'Sprint 2',
+      startDate: '2024-02-17T00:00:00-0500',
+      dueDate: '2024-03-09T23:59:59-0500',
+      endDate: '2024-03-09T23:59:59-0500',
+      gradingType: 'manual',
+      categoryName: 'Sprints',
+      description: 'The Second Sprint',
+      maxFileSize: 10000000,
+      disableHandins: false,
+    }))
+    SendPOST('/assignments', JSON.stringify({
+      courseId: course302,
+      name: 'Sprint 3',
+      startDate: '2024-04-06T00:00:00-0500',
+      dueDate: '2024-04-06T23:59:59-0500',
+      endDate: '2024-04-06T23:59:59-0500',
+      gradingType: 'manual',
+      categoryName: 'Sprints',
+      description: 'The Third Sprint',
+      maxFileSize: 10000000,
+      disableHandins: false,
+    }))
 
 
-        //Submissions
-        const submission_billy_302_1 = await SendPOST("/submissions", JSON.stringify({
-            courseId: course302, assignmentId: assign302_1, userId: userBilly, content: "I finished all my tasks for sprint 1!", type: "text", 
-            submitterIp: "127.0.0.1", submittedBy: userBilly
-        }))
-        SendPOST("/submissions", JSON.stringify({
-            courseId: course302, assignmentId: assign302_2, userId: userBilly, content: "I finished all my tasks for sprint 2!", 
-            type: "text", submitterIp: "127.0.0.1", submittedBy: userBilly
-        }))
-        const submission_bob_312_1 = await SendPOST("/submissions", JSON.stringify({
-            courseId: course312, assignmentId: assign312_1, userId: userBob, content: "jesse pleaseee can i have a good grade pleaseeee", type: "text",
-            submitterIp: "127.0.0.1", submittedBy: userBob
-        }))
-        SendPOST("/submissions", JSON.stringify({
-            courseId: course312, assignmentId: assign312_2, userId: userBob, content: "im begging you jesse please show mercy", type: "text",
-            submitterIp: "127.0.0.1", submittedBy: userBob
-        }))
-        const submission_bob_312_quiz1 = await SendPOST("/submissions", JSON.stringify({
-            courseId: course312, assignmentId: assign312_quiz, userId: userBob, content: "B, D", type: "text", submitterIp: "127.0.0.1", submittedBy: userBob
-        }))
-        
-        
-        //SubmissionProblemScores
-        SendPOST("/submission-problem-scores", JSON.stringify({
-            submissionId: submission_bob_312_quiz1, assignmentProblemId: assign312_quiz_q1, score: 5, feedback: "Good job!", releasedAt: "2024-02-09T17:00:00-0500"
-        }))
-        SendPOST("/submission-problem-scores", JSON.stringify({
-            submissionId: submission_bob_312_quiz1, assignmentProblemId: assign312_quiz_q2, score: 0, feedback: "Incorrect, the correct answer was C.", releasedAt: "2024-02-09T17:00:00-0500"
-        }))
+    //AssignmentProblems
+    const assign312_quiz_q1 = await SendPOST('/assignment-problems', JSON.stringify({
+      assignmentId: assign312_quiz, problemName: 'q1', maxScore: 5,
+    }))
+    const assign312_quiz_q2 = await SendPOST('/assignment-problems', JSON.stringify({
+      assignmentId: assign312_quiz, problemName: 'q2', maxScore: 5,
+    }))
 
 
-        //SubmissionScores
-        SendPOST("/submission-scores", JSON.stringify({
-            submissionId: submission_billy_302_1, score: 90, feedback: "Good work, but please make sure you come to each team meeting fully prepared.", releasedAt: "2024-02-27T07:17:27-0500"
-        }))
-        SendPOST("/submission-scores", JSON.stringify({
-            submissionId: submission_bob_312_1, score: 20, feedback: "no", releasedAt: "2024-03-02T18:34:57-0500"
-        }))
-        SendPOST("/submission-scores", JSON.stringify({
-            submissionId: submission_bob_312_1, score: 5, feedback: "1/2 Questions Correct", releasedAt: "2024-02-09T17:00:00-0500"
-        }))
+    //Submissions
+    const submission_billy_302_1 = await SendPOST('/submissions', JSON.stringify({
+      courseId: course302,
+      assignmentId: assign302_1,
+      userId: userBilly,
+      content: 'I finished all my tasks for sprint 1!',
+      type: 'text',
+      submitterIp: '127.0.0.1',
+      submittedBy: userBilly,
+    }))
+    SendPOST('/submissions', JSON.stringify({
+      courseId: course302,
+      assignmentId: assign302_2,
+      userId: userBilly,
+      content: 'I finished all my tasks for sprint 2!',
+      type: 'text',
+      submitterIp: '127.0.0.1',
+      submittedBy: userBilly,
+    }))
+    const submission_bob_312_1 = await SendPOST('/submissions', JSON.stringify({
+      courseId: course312,
+      assignmentId: assign312_1,
+      userId: userBob,
+      content: 'jesse pleaseee can i have a good grade pleaseeee',
+      type: 'text',
+      submitterIp: '127.0.0.1',
+      submittedBy: userBob,
+    }))
+    SendPOST('/submissions', JSON.stringify({
+      courseId: course312,
+      assignmentId: assign312_2,
+      userId: userBob,
+      content: 'im begging you jesse please show mercy',
+      type: 'text',
+      submitterIp: '127.0.0.1',
+      submittedBy: userBob,
+    }))
+    const submission_bob_312_quiz1 = await SendPOST('/submissions', JSON.stringify({
+      courseId: course312,
+      assignmentId: assign312_quiz,
+      userId: userBob,
+      content: 'B, D',
+      type: 'text',
+      submitterIp: '127.0.0.1',
+      submittedBy: userBob,
+    }))
 
 
-        //AssignmentScore - ROUTE NOT FUNCTIONAL
-        // SendPOST("/assignment-score", JSON.stringify({
-        //     assignmentId: assign302_1, userId: userBilly, score: 90
-        // }))
-        // SendPOST("/assignment-score", JSON.stringify({
-        //     assignmentId: assign312_1, userId: userBob, score: 20
-        // }))
+    //SubmissionProblemScores
+    SendPOST('/submission-problem-scores', JSON.stringify({
+      submissionId: submission_bob_312_quiz1,
+      assignmentProblemId: assign312_quiz_q1,
+      score: 5,
+      feedback: 'Good job!',
+      releasedAt: '2024-02-09T17:00:00-0500',
+    }))
+    SendPOST('/submission-problem-scores', JSON.stringify({
+      submissionId: submission_bob_312_quiz1,
+      assignmentProblemId: assign312_quiz_q2,
+      score: 0,
+      feedback: 'Incorrect, the correct answer was C.',
+      releasedAt: '2024-02-09T17:00:00-0500',
+    }))
 
 
-        //Categories - ROUTE NOT FUNCTIONAL
+    //SubmissionScores
+    SendPOST('/submission-scores', JSON.stringify({
+      submissionId: submission_billy_302_1,
+      score: 90,
+      feedback: 'Good work, but please make sure you come to each team meeting fully prepared.',
+      releasedAt: '2024-02-27T07:17:27-0500',
+    }))
+    SendPOST('/submission-scores', JSON.stringify({
+      submissionId: submission_bob_312_1, score: 20, feedback: 'no', releasedAt: '2024-03-02T18:34:57-0500',
+    }))
+    SendPOST('/submission-scores', JSON.stringify({
+      submissionId: submission_bob_312_1,
+      score: 5,
+      feedback: '1/2 Questions Correct',
+      releasedAt: '2024-02-09T17:00:00-0500',
+    }))
+
+    // non container auto grader
+    SendPOST('/nonContainerAutoGrader', JSON.stringify({
+      'assignmentId': 1,
+      'question': 'What do you call fake spaghetti?',
+      'score': 1,
+      'correctString': '/^An impasta\\.$/',
+      'isRegex': true,
+    }))
+    SendPOST('/nonContainerAutoGrader', JSON.stringify({
+      assignmentId: 1,
+      question: 'why did the chicken cross the road',
+      score: 100,
+      correctString: 'because he wanted to get to the other side',
+      isRegex: false,
+    }))
+    SendPOST('/nonContainerAutoGrader', JSON.stringify({
+      assignmentId: 1,
+      question: 'Why couldn\'t the bicycle stand up by itself?',
+      score: 1,
+      correctString: '/^It was (two|2)-tired\\.$/',
+      isRegex: true,
+    }))
+
+    //AssignmentScore - ROUTE NOT FUNCTIONAL
+    // SendPOST("/assignment-score", JSON.stringify({
+    //     assignmentId: assign302_1, userId: userBilly, score: 90
+    // }))
+    // SendPOST("/assignment-score", JSON.stringify({
+    //     assignmentId: assign312_1, userId: userBob, score: 20
+    // }))
 
 
-        //CategoryScores - ROUTE NOT FUNCTIONAL
+    //Categories - ROUTE NOT FUNCTIONAL
 
 
-        //CourseScores - ROUTE NOT FUNCTIONAL
+    //CategoryScores - ROUTE NOT FUNCTIONAL
 
-        console.log("Script completed successfully!")
-    } catch (e) {
-        console.error(e)
-    }
-    
+
+    //CourseScores - ROUTE NOT FUNCTIONAL
+
+    console.log('Script completed successfully!')
+  } catch (e) {
+    console.error(e)
+  }
+
 }
 
 RunRequests()

--- a/devU-api/src/entities/nonContainerAutoGrader/nonContainerAutoGrader.grader.ts
+++ b/devU-api/src/entities/nonContainerAutoGrader/nonContainerAutoGrader.grader.ts
@@ -3,13 +3,12 @@ import { NonContainerAutoGrader } from 'devu-shared-modules'
 import parseRegex from 'regex-parser'
 
 export function checkAnswer(studentAnswer: string, nonContainerAutoGrader: NonContainerAutoGrader) {
-
   if (nonContainerAutoGrader.isRegex) {
     // Create a regex pattern
     // we use parseRegex lib here because regular Regex() class will try to add its own escape characters
     // we don't want that since we know correct string should always contain a valid regex
     const pattern = parseRegex(nonContainerAutoGrader.correctString)
-    // Use the test method
+
     const isMatch: boolean = pattern.test(studentAnswer)
     if (isMatch) {
       return nonContainerAutoGrader.score

--- a/devU-api/src/entities/nonContainerAutoGrader/nonContainerAutoGrader.grader.ts
+++ b/devU-api/src/entities/nonContainerAutoGrader/nonContainerAutoGrader.grader.ts
@@ -1,8 +1,23 @@
 import { NonContainerAutoGrader } from 'devu-shared-modules'
 
 export async function checkAnswer(studentAnswer: string, nonContainerAutoGrader: NonContainerAutoGrader) {
-  if (studentAnswer === nonContainerAutoGrader.correctString) {
-    return nonContainerAutoGrader.score
+
+  if (nonContainerAutoGrader.isRegex) {
+    // Create a regex pattern
+    const pattern: RegExp = new RegExp(nonContainerAutoGrader.correctString)
+    // Use the test method
+    const isMatch: boolean = pattern.test(studentAnswer)
+    if (isMatch) {
+      return nonContainerAutoGrader.score
+    }
+  } else {
+    // if no regex is set use normal string matching
+    if (studentAnswer === nonContainerAutoGrader.correctString) {
+      return nonContainerAutoGrader.score
+    }
   }
-  return null
+
+  // default value to return if all conditions fail to execute
+  // i.e. student has the incorrect answer or improperly formatted
+  return 0
 }

--- a/devU-api/src/entities/nonContainerAutoGrader/nonContainerAutoGrader.grader.ts
+++ b/devU-api/src/entities/nonContainerAutoGrader/nonContainerAutoGrader.grader.ts
@@ -1,10 +1,14 @@
 import { NonContainerAutoGrader } from 'devu-shared-modules'
 
-export async function checkAnswer(studentAnswer: string, nonContainerAutoGrader: NonContainerAutoGrader) {
+import parseRegex from 'regex-parser'
+
+export function checkAnswer(studentAnswer: string, nonContainerAutoGrader: NonContainerAutoGrader) {
 
   if (nonContainerAutoGrader.isRegex) {
     // Create a regex pattern
-    const pattern: RegExp = new RegExp(nonContainerAutoGrader.correctString)
+    // we use parseRegex lib here because regular Regex() class will try to add its own escape characters
+    // we don't want that since we know correct string should always contain a valid regex
+    const pattern = parseRegex(nonContainerAutoGrader.correctString)
     // Use the test method
     const isMatch: boolean = pattern.test(studentAnswer)
     if (isMatch) {
@@ -18,6 +22,6 @@ export async function checkAnswer(studentAnswer: string, nonContainerAutoGrader:
   }
 
   // default value to return if all conditions fail to execute
-  // i.e. student has the incorrect answer or improperly formatted
+  // i.e. the answer is incorrect or improperly formatted
   return 0
 }

--- a/devU-api/src/entities/nonContainerAutoGrader/nonContainerAutoGrader.model.ts
+++ b/devU-api/src/entities/nonContainerAutoGrader/nonContainerAutoGrader.model.ts
@@ -35,7 +35,7 @@ export default class NonContainerAutoGraderModel {
   @Column({ name: 'score' })
   score: number
 
-  @Column({ name: 'is_regex' })
+  @Column({ name: 'is_regex', type: 'boolean' })
   isRegex: boolean
 
   @Column({ name: 'correct_string', length: 128 })

--- a/devU-api/src/entities/nonContainerAutoGrader/nonContainerAutoGrader.model.ts
+++ b/devU-api/src/entities/nonContainerAutoGrader/nonContainerAutoGrader.model.ts
@@ -1,40 +1,43 @@
 import {
-    Column,
-    CreateDateColumn,
-    DeleteDateColumn,
-    Entity,
-    JoinColumn,
-    ManyToOne,
-    PrimaryGeneratedColumn,
-    UpdateDateColumn,
+  Column,
+  CreateDateColumn,
+  DeleteDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
 } from 'typeorm'
 import AssignmentModel from '../assignment/assignment.model'
 
 @Entity({ name: 'nonContainerAutoGrader' })
 export default class NonContainerAutoGraderModel {
-    @PrimaryGeneratedColumn()
-    id: number
+  @PrimaryGeneratedColumn()
+  id: number
 
-    @CreateDateColumn({ name: 'created_at' })
-    createdAt: Date
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date
 
-    @UpdateDateColumn({ name: 'updated_at' })
-    updatedAt: Date
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date
 
-    @DeleteDateColumn({ name: 'deleted_at' })
-    deletedAt?: Date
+  @DeleteDateColumn({ name: 'deleted_at' })
+  deletedAt?: Date
 
-    @Column({ name: 'assignment_id' })
-    @JoinColumn({ name: 'assignment_id' })
-    @ManyToOne(() => AssignmentModel)
-    assignmentId: number
+  @Column({ name: 'assignment_id' })
+  @JoinColumn({ name: 'assignment_id' })
+  @ManyToOne(() => AssignmentModel)
+  assignmentId: number
 
-    @Column({name:'question', length: 128 })
-    question: string
+  @Column({ name: 'question', length: 128 })
+  question: string
 
-    @Column({name:'score'})
-    score: number
+  @Column({ name: 'score' })
+  score: number
 
-    @Column({ name:'correct_string', length: 128 })
-    correctString: string
+  @Column({ name: 'is_regex' })
+  isRegex: boolean
+
+  @Column({ name: 'correct_string', length: 128 })
+  correctString: string
 }

--- a/devU-api/src/entities/nonContainerAutoGrader/nonContainerAutoGrader.serializer.ts
+++ b/devU-api/src/entities/nonContainerAutoGrader/nonContainerAutoGrader.serializer.ts
@@ -9,6 +9,7 @@ export function serialize(nonContainerAutoGrader: NonContainerAutoGraderModel): 
     question: nonContainerAutoGrader.question,
     score: nonContainerAutoGrader.score,
     correctString: nonContainerAutoGrader.correctString,
+    isRegex: nonContainerAutoGrader.isRegex,
     createdAt: nonContainerAutoGrader.createdAt.toISOString(),
     updatedAt: nonContainerAutoGrader.updatedAt.toISOString(),
   }

--- a/devU-api/src/entities/nonContainerAutoGrader/nonContainerAutoGrader.service.ts
+++ b/devU-api/src/entities/nonContainerAutoGrader/nonContainerAutoGrader.service.ts
@@ -9,10 +9,10 @@ export async function create(nonContainerQuestion: NonContainerAutoGrader) {
 }
 
 export async function update(nonContainerQuestion: NonContainerAutoGrader) {
-  const { id, question, score, correctString } = nonContainerQuestion
+  const { id, question, score, correctString, isRegex, assignmentId } = nonContainerQuestion
   if (!id) throw new Error('Missing Id')
 
-  return await connect().update(id, { score, question, correctString })
+  return await connect().update(id, { score, question, correctString, isRegex, assignmentId })
 }
 
 export async function _delete(id: number) {

--- a/devU-api/src/entities/nonContainerAutoGrader/nonContainerAutoGrader.validator.ts
+++ b/devU-api/src/entities/nonContainerAutoGrader/nonContainerAutoGrader.validator.ts
@@ -4,14 +4,14 @@ import validate from '../../middleware/validator/generic.validator'
 const correctString = check('correctString').isString().trim().isLength({ max: 128 })
 const question = check('question').isString().trim().isLength({ max: 128 })
 const score = check('score').isNumeric()
-const assignmentId = check('assignmentId').isNumeric()
+const isRegex = check('isRegex').isBoolean()
 
 const validator = [
   correctString,
   validate,
   question,
   score,
-  assignmentId,
+  isRegex,
 ]
 
 export default validator

--- a/devU-api/src/entities/nonContainerAutoGrader/tests/nonContainerAutoGrader.grader.test.ts
+++ b/devU-api/src/entities/nonContainerAutoGrader/tests/nonContainerAutoGrader.grader.test.ts
@@ -1,0 +1,72 @@
+import { NonContainerAutoGrader } from 'devu-shared-modules'
+
+import { checkAnswer } from '../nonContainerAutoGrader.grader'
+
+
+describe('NonContainerAutoGrader grader', () => {
+  let mockQuestionWithoutRegex: NonContainerAutoGrader
+
+  describe('NonContainerAutoGrader without regex', () => {
+    beforeEach(() => {
+      mockQuestionWithoutRegex = {
+        id: 23,
+        question: 'The Answer to the Ultimate Question of Life, the Universe, and Everything',
+        correctString: '42',
+        score: 1,
+        assignmentId: 8,
+        isRegex: false,
+      }
+    })
+
+    test('Student correct answer', () => {
+      const studentAnswer = '42'
+      const expectedResult = checkAnswer(studentAnswer, mockQuestionWithoutRegex)
+
+      expect(expectedResult).toEqual(mockQuestionWithoutRegex.score)
+    })
+
+    test('Student messed up', () => {
+      const studentAnswer = '69'
+      const expectedResult = checkAnswer(studentAnswer, mockQuestionWithoutRegex)
+
+      expect(expectedResult).toEqual(0)
+    })
+  })
+
+  describe('NonContainerAutoGrader with regex', () => {
+    let mockQuestionWithRegex: NonContainerAutoGrader
+
+    beforeEach(() => {
+      mockQuestionWithRegex = {
+        id: 23,
+        question: 'What was the last ever Dolphin message',
+        // regex to match this exact sentence and is case-sensitive
+        correctString: '/So long, and thanks for all the fish\./gm',
+        score: 1,
+        assignmentId: 8,
+        isRegex: true,
+      }
+    })
+
+    test('answer match with exact casing', () => {
+      const studentAnswer = 'So long, and thanks for all the fish.'
+      const expectedResult = checkAnswer(studentAnswer, mockQuestionWithRegex)
+
+      expect(expectedResult).toEqual(mockQuestionWithRegex.score)
+    })
+
+    test('Incorrect answer', () => {
+      const studentAnswer = '~~dolphin noises~~'
+      const expectedResult = checkAnswer(studentAnswer, mockQuestionWithRegex)
+
+      expect(expectedResult).toEqual(0)
+    })
+
+    test('correct answer but incorrect formatting', () => {
+      const studentAnswer = 'So long, and thanks for all the fish.'.toUpperCase()
+      const expectedResult = checkAnswer(studentAnswer, mockQuestionWithRegex)
+
+      expect(expectedResult).toEqual(0)
+    })
+  })
+})

--- a/devU-api/src/entities/nonContainerAutoGrader/tests/nonContainerAutoGrader.serializer.test.ts
+++ b/devU-api/src/entities/nonContainerAutoGrader/tests/nonContainerAutoGrader.serializer.test.ts
@@ -14,6 +14,7 @@ describe('NonContainerAutoGrader Serializer', () => {
     mockQuestion.question = 'The Answer to the Ultimate Question of Life, the Universe, and Everything'
     mockQuestion.correctString = '42'
     mockQuestion.score = 1
+    mockQuestion.isRegex = false
     mockQuestion.createdAt = new Date()
     mockQuestion.updatedAt = new Date()
   })

--- a/devU-api/src/entities/nonContainerAutoGrader/tests/nonContainerAutoGrader.serializer.test.ts
+++ b/devU-api/src/entities/nonContainerAutoGrader/tests/nonContainerAutoGrader.serializer.test.ts
@@ -6,7 +6,7 @@ import Testing from '../../../utils/testing.utils'
 
 let mockQuestion: NonContainerAutoGrader
 
-describe('Category Serializer', () => {
+describe('NonContainerAutoGrader Serializer', () => {
   beforeEach(() => {
     mockQuestion = Testing.generateTypeOrm<NonContainerAutoGrader>(NonContainerAutoGrader)
 
@@ -18,7 +18,7 @@ describe('Category Serializer', () => {
     mockQuestion.updatedAt = new Date()
   })
 
-  describe('Serializing category', () => {
+  describe('Serializing NonContainerAutoGrader', () => {
     test('NonContainerAutoGrader values exist in the response', () => {
       const expectedResult = serialize(mockQuestion)
 

--- a/devU-api/src/migration/1708215731032-entityFixUp.ts
+++ b/devU-api/src/migration/1708215731032-entityFixUp.ts
@@ -1,4 +1,4 @@
-import {MigrationInterface, QueryRunner} from "typeorm";
+import { MigrationInterface, QueryRunner } from 'typeorm'
 
 export class entityFixUp1708215731032 implements MigrationInterface {
     name = 'entityFixUp1708215731032'
@@ -48,6 +48,8 @@ export class entityFixUp1708215731032 implements MigrationInterface {
         await queryRunner.query(`ALTER TABLE "submission_scores" ADD CONSTRAINT "FK_60b6432533ce75c224598af6bf5" FOREIGN KEY ("submission_id") REFERENCES "submissions"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
         await queryRunner.query(`ALTER TABLE "user_courses" ADD CONSTRAINT "FK_7ecb10d15b858768c36d37727f9" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
         await queryRunner.query(`ALTER TABLE "user_courses" ADD CONSTRAINT "FK_d65a2771413a10753d76937b3d6" FOREIGN KEY ("course_id") REFERENCES "courses"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "nonContainerAutoGrader"
+            ADD "is_regex" boolean NOT NULL;`)
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {

--- a/devu-shared/src/types/nonContainerAutoGrader.types.ts
+++ b/devu-shared/src/types/nonContainerAutoGrader.types.ts
@@ -4,6 +4,7 @@ export type NonContainerAutoGrader = {
     question: string
     score:number
     correctString: string
+    isRegex: boolean
     createdAt?: string
     updatedAt?: string
 }


### PR DESCRIPTION
## Proposed changes
--------------------
This resolves #47 and updates the function in #40 to use regex

Adds isRegex fields to model and type, allowing NCAG to use regex.

## Types of changes
--------------------
What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
--------------------
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code._

- [x] My changeset covers only what is described above (no extraneous changes)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments
--------------------

Since I trouble adding is_regex column for nacg in migration files using instructions in the readme

I used  ```npm run typeorm -- schema:log```

Which outputted the query to add is_regex 
``` `ALTER TABLE "nonContainerAutoGrader" ADD "is_regex" boolean NOT NULL;` ```

and I manually added the line in ``devU-api/src/migration/1708215731032-entityFixUp.ts``

```await queryRunner.query(`ALTER TABLE "nonContainerAutoGrader" ADD "is_regex" boolean NOT NULL;`)```

This feels a bit hacky but I tested with populate-db script and everything is working so I think it should be fine.


Also I feel there should be more tests for the grader function but not sure what else to add
