### PR TITLE
Added manual grading to frontend

### DIFF
--- a/devU-client/src/components/pages/submissionDetailPage.tsx
+++ b/devU-client/src/components/pages/submissionDetailPage.tsx
@@ -8,12 +8,17 @@ import { SubmissionScore, SubmissionProblemScore, Submission, Assignment, Assign
 import { Link, useParams } from 'react-router-dom'
 import Button from '../shared/inputs/button'
 import TextField from '../shared/inputs/textField'
+import { useActionless } from 'redux/hooks'
+import { SET_ALERT } from 'redux/types/active.types'
 
 
 
-const SubmissionDetailPage = () => { 
+const SubmissionDetailPage = (props : any) => { 
+    const { state } = props.location
+
     const [loading, setLoading] = useState(true)
     const [error, setError] = useState(null)
+    const [setAlert] = useActionless(SET_ALERT)
     
     const { submissionId } = useParams<{submissionId: string}>()
     const [submissionScore, setSubmissionScore] = useState<SubmissionScore | null>(null)
@@ -21,6 +26,14 @@ const SubmissionDetailPage = () => {
     const [submission, setSubmission] = useState<Submission>()
     const [assignmentProblems, setAssignmentProblems] = useState(new Array<AssignmentProblem>())
     const [assignment, setAssignment] = useState<Assignment>()
+
+    const [showManualGrade, setToggleManualGrade] = useState(false)
+    const [formData, setFormData] = useState({
+        submissionId: state.id,
+        score: 0,
+        feedback: '',
+        releasedAt: "2024-10-05T14:48:00.00Z"
+    })
 
     const fetchData = async () => {
         try {

--- a/devU-client/src/components/pages/submissionDetailPage.tsx
+++ b/devU-client/src/components/pages/submissionDetailPage.tsx
@@ -3,18 +3,28 @@ import React,{useState,useEffect} from 'react'
 import PageWrapper from 'components/shared/layouts/pageWrapper'
 import RequestService from 'services/request.service'
 import { SubmissionScore } from 'devu-shared-modules'
+import Button from 'components/shared/inputs/button'
+import TextField from 'components/shared/inputs/textField'
+import { useActionless } from 'redux/hooks'
+import { SET_ALERT } from 'redux/types/active.types'
 
 const SubmissionDetailPage = (props : any) => { 
     const { state } = props.location
+    const [setAlert] = useActionless(SET_ALERT)
     const [submissionScore, setSubmissionScore] = useState<SubmissionScore | null>(null)
+    const [showManualGrade, setToggleManualGrade] = useState<boolean>(false)
+    const [formData, setFormData] = useState({
+        submissionId: state.id,
+        score: 0,
+        feedback: '',
+        releasedAt: "2024-10-05T14:48:00.000Z",
+    })
 
     const fetchData = async () => {
         try {
             const data = await RequestService.get<SubmissionScore>(
                 `/api/submission-scores/${state.id}`
             )
-            console.log(data)
-            console.log(typeof(data))
             setSubmissionScore(data)
         } catch (error) {
             console.log('Error fetching submission problem scores', error)
@@ -25,9 +35,49 @@ const SubmissionDetailPage = (props : any) => {
         fetchData()
     }, [])
 
+    const handleClick = () => {
+        setToggleManualGrade(!showManualGrade)
+    }
+
+    const handleChange = (value : string, e : React.ChangeEvent<HTMLInputElement>) => {
+        const key = e.target.id
+        setFormData(prevState => ({...prevState,[key] : value}))
+    }
+
+    const handleManualGrade = async () => {
+        if (submissionScore) {
+            // Update the submission score
+            console.log('Submission Exists')
+            await RequestService.put( `/api/submission-scores/${submissionScore.id}`, formData)
+            .then(() => {
+                setAlert({ autoDelete: true, type: 'success', message: 'Submission Score Updated' })
+            
+            })
+        }
+        else {
+            // Create a new submission score
+            console.log('No Submission')
+            await RequestService.post( `/api/submission-scores`, formData)
+            .then(() => {
+                setAlert({ autoDelete: true, type: 'success', message: 'Submission Score Created' })
+            })
+        }
+    }
+
     return(
         <PageWrapper>
             <h1>Submission Detail</h1>
+
+            <Button onClick={handleClick}>Manually Grade</Button>
+
+            {showManualGrade && (
+                <div>
+                    <TextField id="score" placeholder="Score" onChange={handleChange}/>
+                    <TextField id="feedback" placeholder="Feedback" onChange={handleChange}/>
+                    <Button onClick={handleManualGrade}>Submit</Button>
+                </div>
+            )}
+
             {submissionScore ? (
                 <div>
                     <h1>{submissionScore.submissionId}</h1>
@@ -35,7 +85,9 @@ const SubmissionDetailPage = (props : any) => {
                     <h3>{submissionScore.feedback}</h3>
                     <br></br>
                 </div>
-            ) : null}
+            ) : (
+                <h1>No submission score/feedback available</h1>
+            )}
         </PageWrapper>
     )
 }


### PR DESCRIPTION
Added manual grading to the frontend. There is a bug where the api doesn't create the releasedAt date when updating a submission score entity so I hardcoded a date.

## Proposed changes
--------------------
Added a button that makes textfields appear for manual grading of submissions.

Resolves #74 

## Types of changes
--------------------
What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
--------------------
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code._

- [x ] My changeset covers only what is described above (no extraneous changes)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
--------------------
Right now,there is a bug when updating a submission score which requires a releasedBy field to be passed through the frontend instead of being created by the backend. This field is hardcoded on the frontend and needs to be removed in the future. 